### PR TITLE
Adding manual config option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,6 @@ fluentd_plugins:
   - fluent-plugin-mysqlslowquery
 
 fluentd_external_plugins: []
+
+fluentd_manual_config: false
+fluentd_manual_config_contents: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,18 @@
     owner: td-agent
     group: "td-agent"
     mode: 0640
+  when: not fluentd_manual_config
+  notify: restart fluentd
+  tags: ['fluentd']
+
+- name: place the /etc/td-agent/td-agent.conf file
+  template:
+    src: etc.td-agent.td-agent-manual.conf.j2
+    dest: /etc/td-agent/td-agent.conf
+    owner: td-agent
+    group: "td-agent"
+    mode: 0640
+  when: fluentd_manual_config
   notify: restart fluentd
   tags: ['fluentd']
 

--- a/templates/etc.td-agent.td-agent-manual.conf.j2
+++ b/templates/etc.td-agent.td-agent-manual.conf.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+{{ fluentd_manual_config_contents }}


### PR DESCRIPTION
Eventually this role will entirely rewrite the fluentd config parser inside a jinja template and it will be awful, so for complicated use cases I've included the ability to just roll your own config and shove it into td-agent.conf via an ansible var