### PR TITLE
making default repo path not be hard coded to cent7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Set Repository information
-fluentd_repo_url: http://packages.treasuredata.com/2/redhat/7/\$basearch
+fluentd_repo_url: http://packages.treasuredata.com/2/redhat/\$releasever/\$basearch
 fluentd_gpg_key_url: https://packages.treasuredata.com/GPG-KEY-td-agent
 
 # Set the sources. You can set a syslog type for generic syslog capture and a forward type


### PR DESCRIPTION
The default was to hardcode to major version 7 instead of using $releasever in the repo file, which doesn't play nice with versions of centos that are ... not 7.